### PR TITLE
Remove pytest and coverage as push hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
         name: Running flake8 from local poetry env
         entry: poetry run flake8 .
         language: system
+        pass_filenames: false
         files: ".*.py"
         exclude: "{{ cookiecutter.project_slug }}"
     -   id: isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,10 @@ exclude =
     .git,
     # There's no value in checking cache directories
     __pycache__,
-    # Don't check virtualenv
+    # No need to look in the virtual env folder
+    .env,
+    .venv/,
     venv/,
-    .venv/
 max_line_length = 100
 # B001 is already enabled for flake8-bugbear
 extend-ignore = E722

--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -42,22 +42,3 @@ repos:
         # Max 7 arguments allowed, show only warnings, sort by CCN, exclude .venv
         args: ["--CCN", "8", "-a", "7", "-w", "-s", "cyclomatic_complexity", "-x", ".\\.venv\\*"]
         language: python
-    {% if cookiecutter.pytest == "y" -%}
-    -   id: pytest
-        name: Running tests using pytest from local poetry env
-        entry: poetry run coverage run -m pytest
-        args: ["-x"]
-        language: system
-        types:
-          - python
-        pass_filenames: false
-        stages: [push]
-    -   id: coverage
-        name: Generating coverage report
-        entry: poetry run coverage report -m
-        language: system
-        types:
-          - python
-        pass_filenames: false
-        stages: [push]
-    {%- endif %}

--- a/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_slug }}/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
         name: Running flake8 from local poetry env
         entry: poetry run flake8 .
         language: system
+        pass_filenames: false
         files: ".*.py"
     -   id: isort
         name: Running isort from local poetry env

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -39,9 +39,27 @@ quiet = true
 plugins = ["covdefaults"]
 
 [tool.coverage.report]
+branch = true
 fail_under = 95
 omit = [
-    "logger.py"
+    "logger.py",
+    "*/tests/*","
+]
+exclude_lines = [
+    # Have to re-enable the standard pragma
+    "pragma: no cover",
+
+    # Don't complain about missing debug-only code:
+    "def __repr__",
+    "if self\.debug",
+
+    # Don't complain if tests don't hit defensive assertion code:
+    "raise AssertionError",
+    "raise NotImplementedError",
+
+    # Don't complain if non-runnable code isn't run:
+    "if 0:",
+    "if __name__ == .__main__.:",
 ]
 {%- endif %}
 

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -43,7 +43,7 @@ branch = true
 fail_under = 95
 omit = [
     "logger.py",
-    "*/tests/*","
+    "*/tests/*",
 ]
 exclude_lines = [
     # Have to re-enable the standard pragma

--- a/{{ cookiecutter.project_slug }}/setup.cfg
+++ b/{{ cookiecutter.project_slug }}/setup.cfg
@@ -4,9 +4,10 @@ exclude =
     .git,
     # There's no value in checking cache directories
     __pycache__,
-    # Don't check virtualenv
+    # No need to look in the virtual env folder
+    .env,
+    .venv/,
     venv/,
-    .venv/
 max_line_length = 100
 # B001 is already enabled for flake8-bugbear
 extend-ignore = E722


### PR DESCRIPTION
Pytest exists as code 5 and coverage fails at 0 percent coverage (--fail under = 95 is turned on by default), and both of these cause the hooks to fail. 
This PR removes them until <issue> can find a way around it.